### PR TITLE
展示转发和引用推文的完整上下文

### DIFF
--- a/src/pipeline.py
+++ b/src/pipeline.py
@@ -73,11 +73,12 @@ TRANSLATE_BATCH_SIZE = int(os.environ.get("TRANSLATE_BATCH_SIZE", "10"))
 # 批量翻译 prompt — 一次 API 调用处理多条推文
 BATCH_PROMPT_TEMPLATE = """\
 将以下 {n} 条推文分别翻译成中文。
+部分推文含有引用或转发内容，请结合全文理解完整信息。
 
 格式要求（严格按编号顺序输出，每条用 [编号] 分隔，不添加任何额外文字）：
 [1]
 TITLE: 一句话核心观点（不超过 20 字）
-SUMMARY: 中文翻译（保留原意，不超过 100 字）
+SUMMARY: 中文翻译（保留原意，如有引用请概括完整背景，不超过 150 字）
 
 [2]
 TITLE: ...
@@ -85,6 +86,26 @@ SUMMARY: ...
 
 推文原文：
 {tweets}"""
+
+
+def _build_tweet_prompt_text(tweet: dict) -> str:
+    """
+    为 LLM 翻译构建上下文感知的文本。
+    若推文包含引用/转发内容，将其纳入提示词以生成更准确的翻译。
+    """
+    text = tweet.get("text", "")
+    context_text = tweet.get("context_text", "")
+    context_author = tweet.get("context_author", "")
+    is_repost = tweet.get("is_repost", False)
+
+    if not context_text:
+        return text
+
+    author_note = f"@{context_author}" if context_author else "某用户"
+    if is_repost:
+        return f"（转发自 {author_note}）\n{text}"
+    else:
+        return f"（评论/引用了 {author_note} 的推文）\n原帖：{context_text}\n回应：{text}"
 
 
 # ---------------------------------------------------------------------------
@@ -127,6 +148,10 @@ class TweetEntry:
     created_at: str
     title: str = ""
     summary: str = ""
+    context_text: str = ""    # 被引用/转发推文的内容
+    context_author: str = ""  # 被引用/转发推文的作者 handle
+    context_url: str = ""     # 被引用推文的链接
+    is_repost: bool = False   # True 表示纯转推（无评论）
 
 
 # ---------------------------------------------------------------------------
@@ -190,10 +215,16 @@ def _parse_twitter_date(date_str: str) -> str:
 
 def fetch_tweets(handle: str, client: TweeterPy) -> list[dict]:
     """
-    抓取指定 Twitter 用户的最近推文（排除转推和回复）。
+    抓取指定 Twitter 用户的最近推文（排除无法解析的转推和回复）。
+    对于含引用推文的帖子，提取被引用内容作为上下文（context_text/context_author/context_url）。
+    对于转推（RT @），提取被转推的原始内容，以便展示完整信息。
     任何错误都返回空列表，不抛出异常（单人失败不影响整体流程）。
 
-    返回格式：[{"id": str, "text": str, "created_at": str, "url": str}]
+    返回格式：[{
+        "id": str, "text": str, "created_at": str, "url": str,
+        "context_text": str, "context_author": str, "context_url": str,
+        "is_repost": bool,
+    }]
     """
     try:
         response = client.get_user_tweets(handle, total=FETCH_TWEETS_PER_USER)
@@ -204,23 +235,47 @@ def fetch_tweets(handle: str, client: TweeterPy) -> list[dict]:
         raw_count = len(response["data"])
         results = []
         skipped_no_text = skipped_no_id = skipped_rt = skipped_reply = 0
+        repost_count = 0
         for item in response["data"]:
             tweet = Tweet(item)
             # tweeterpy's find_nested_key() can return a list when a tweet
-            # contains nested tweet data (e.g. quoted tweets).  Normalise to
-            # a plain string by taking the first element so that downstream
-            # str operations like .startswith() don't raise TypeError.
-            full_text = tweet.full_text
-            if isinstance(full_text, list):
-                full_text = full_text[0] if full_text else None
+            # contains nested tweet data (e.g. quoted tweets).  The first
+            # element is the main tweet text; the second (if present) is the
+            # quoted tweet's text which we capture as context.
+            full_texts = tweet.full_text
+            context_text = ""
+            context_author = ""
+            context_url = ""
+
+            if isinstance(full_texts, list):
+                full_text = full_texts[0] if full_texts else None
+                if len(full_texts) > 1:
+                    context_text = full_texts[1] or ""
+            else:
+                full_text = full_texts
 
             if not full_text:
                 skipped_no_text += 1
                 continue
-            # 排除转推
+
+            # 处理转推 — 提取原始内容和作者，而非直接跳过
+            is_repost = False
             if full_text.startswith("RT @"):
-                skipped_rt += 1
-                continue
+                rt_match = re.match(r"RT @(\w+): (.*)", full_text, re.DOTALL)
+                if rt_match:
+                    rt_handle = rt_match.group(1)
+                    rt_content = rt_match.group(2).rstrip("…").strip()
+                    # 优先使用嵌套数据中的完整文本（避免 RT 截断问题）
+                    if not context_text:
+                        context_text = rt_content
+                    context_author = rt_handle
+                    full_text = context_text  # 用原始内容替换 RT @ 前缀
+                    is_repost = True
+                    repost_count += 1
+                else:
+                    skipped_rt += 1
+                    continue
+
             # 排除回复 — in_reply_to_status_id_str may also be a list
             reply_id = tweet.in_reply_to_status_id_str
             if isinstance(reply_id, list):
@@ -229,20 +284,47 @@ def fetch_tweets(handle: str, client: TweeterPy) -> list[dict]:
                 skipped_reply += 1
                 continue
 
-            tweet_id = tweet.rest_id or tweet.id_str
+            # 提取引用推文的作者（当上下文文本存在但作者未知时）
+            if context_text and not context_author:
+                screen_names = tweet.screen_name
+                if isinstance(screen_names, list) and len(screen_names) > 1:
+                    context_author = screen_names[1]
+
+            # 处理 rest_id / id_str 可能为列表的情况（多层嵌套推文）
+            rest_id_raw = tweet.rest_id
+            if isinstance(rest_id_raw, list):
+                quoted_rest_id = rest_id_raw[1] if len(rest_id_raw) > 1 else None
+                rest_id_val = rest_id_raw[0] if rest_id_raw else None
+            else:
+                quoted_rest_id = None
+                rest_id_val = rest_id_raw
+
+            id_str_raw = tweet.id_str
+            id_str_val = id_str_raw[0] if isinstance(id_str_raw, list) else id_str_raw
+
+            tweet_id = rest_id_val or id_str_val
             if not tweet_id:
                 skipped_no_id += 1
                 continue
+
+            # 构建引用推文的 URL（如有足够信息）
+            if context_text and context_author and not context_url and quoted_rest_id:
+                context_url = f"https://x.com/{context_author}/status/{quoted_rest_id}"
+
             results.append({
                 "id": tweet_id,
                 "text": full_text,
                 "created_at": _parse_twitter_date(tweet.created_at),
                 "url": f"https://x.com/{handle}/status/{tweet_id}",
+                "context_text": context_text,
+                "context_author": context_author,
+                "context_url": context_url,
+                "is_repost": is_repost,
             })
 
         logger.info(
             f"  @{handle}: 原始={raw_count}, 无文本={skipped_no_text}, 无ID={skipped_no_id}, "
-            f"转推={skipped_rt}, 回复={skipped_reply}, 有效={len(results)}"
+            f"转推(含上下文)={repost_count}, 转推(无法解析)={skipped_rt}, 回复={skipped_reply}, 有效={len(results)}"
         )
         return results
     except Exception as e:
@@ -344,7 +426,9 @@ def translate_batch(tweets: list[dict], api_key: str) -> list[dict[str, str]]:
         for t in tweets
     ]
 
-    tweets_block = "\n\n".join(f"[{i + 1}]\n{t['text']}" for i, t in enumerate(tweets))
+    tweets_block = "\n\n".join(
+        f"[{i + 1}]\n{_build_tweet_prompt_text(t)}" for i, t in enumerate(tweets)
+    )
     prompt = BATCH_PROMPT_TEMPLATE.format(n=len(tweets), tweets=tweets_block)
 
     for attempt in range(3):
@@ -507,6 +591,10 @@ def main() -> None:
                 created_at=tweet["created_at"],
                 title=translated["title"],
                 summary=translated["summary"],
+                context_text=tweet.get("context_text", ""),
+                context_author=tweet.get("context_author", ""),
+                context_url=tweet.get("context_url", ""),
+                is_repost=tweet.get("is_repost", False),
             ))
             new_ids.add(tweet["id"])
 

--- a/templates/day.html.j2
+++ b/templates/day.html.j2
@@ -219,6 +219,53 @@
     }
     .card-link a:hover { background: var(--accent-bg); }
 
+    /* ── Context block (quoted / retweeted tweet) ── */
+    .card-context {
+      background: var(--surface-2);
+      border: 1px solid var(--border);
+      border-left: 2px solid var(--border-2);
+      border-radius: var(--radius-md);
+      padding: 10px 14px;
+      margin-bottom: 14px;
+      font-size: 13px;
+      line-height: 1.65;
+    }
+    .context-meta {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      margin-bottom: 5px;
+    }
+    .context-label {
+      font-family: 'Geist Mono', monospace;
+      font-size: 10px;
+      color: var(--text-3);
+      letter-spacing: .05em;
+      text-transform: uppercase;
+    }
+    .context-author {
+      font-family: 'Geist Mono', monospace;
+      font-size: 11px;
+      color: var(--accent);
+      font-weight: 500;
+      text-decoration: none;
+    }
+    .context-author:hover { text-decoration: underline; }
+    .context-body {
+      color: var(--text-2);
+      font-style: italic;
+    }
+    .card-repost-badge {
+      display: inline-flex;
+      align-items: center;
+      gap: 4px;
+      font-family: 'Geist Mono', monospace;
+      font-size: 11px;
+      color: var(--text-3);
+      margin-bottom: 12px;
+      letter-spacing: .02em;
+    }
+
     /* ── Empty state ── */
     .empty {
       text-align: center;
@@ -316,6 +363,26 @@
       {% endif %}
 
       <div class="card-summary">{{ entry.summary }}</div>
+
+      {% if entry.is_repost and entry.context_author %}
+      <div class="card-repost-badge">↩ 转发自 @{{ entry.context_author }}</div>
+      {% endif %}
+
+      {% if entry.context_text and not entry.is_repost %}
+      <div class="card-context">
+        <div class="context-meta">
+          <span class="context-label">引用</span>
+          {% if entry.context_author %}
+          {% if entry.context_url %}
+          <a class="context-author" href="{{ entry.context_url }}" target="_blank" rel="noopener">@{{ entry.context_author }}</a>
+          {% else %}
+          <span class="context-author">@{{ entry.context_author }}</span>
+          {% endif %}
+          {% endif %}
+        </div>
+        <div class="context-body">{{ entry.context_text }}</div>
+      </div>
+      {% endif %}
 
       <div class="card-original">{{ entry.original_text }}</div>
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -16,7 +16,7 @@ pytest 测试 — pipeline.py 核心函数
   test_fetch_tweets_user_not_found    — 用户不存在时返回 []
   test_fetch_tweets_no_tweets         — 无推文时返回 []
   test_fetch_tweets_exception         — 任何异常返回 []（不抛出）
-  test_fetch_tweets_skip_retweets     — 过滤转推
+  test_fetch_tweets_includes_retweets_with_context — 转推包含上下文
   test_fetch_tweets_skip_replies      — 过滤回复
   test_translate_success              — 正常翻译返回 title/summary/original
   test_translate_api_failure          — API 异常时返回 fallback dict
@@ -384,8 +384,8 @@ def test_fetch_tweets_exception():
     assert result == []
 
 
-def test_fetch_tweets_skip_retweets():
-    """以 'RT @' 开头的推文应被过滤。"""
+def test_fetch_tweets_includes_retweets_with_context():
+    """以 'RT @' 开头的推文应被包含，并提取 context_author 和 context_text。"""
     mock_client = MagicMock()
     mock_tweet = _make_tweet_item("111", "RT @someone: some text")
 
@@ -393,7 +393,11 @@ def test_fetch_tweets_skip_retweets():
         mock_client.get_user_tweets.return_value = {"data": [MagicMock()]}
         result = fetch_tweets("sama", mock_client)
 
-    assert result == []
+    assert len(result) == 1
+    assert result[0]["text"] == "some text"
+    assert result[0]["context_author"] == "someone"
+    assert result[0]["context_text"] == "some text"
+    assert result[0]["is_repost"] is True
 
 
 def test_fetch_tweets_skip_replies():
@@ -408,8 +412,8 @@ def test_fetch_tweets_skip_replies():
     assert result == []
 
 
-def test_fetch_tweets_full_text_is_list():
-    """tweeterpy 返回 full_text 为列表时，应取第一个元素正常处理。"""
+def test_fetch_tweets_full_text_is_list_captures_context():
+    """tweeterpy 返回 full_text 为列表时，第二个元素应被捕获为引用上下文。"""
     mock_client = MagicMock()
     mock_tweet = _make_tweet_item("111", ["AGI is near", "quoted tweet text"])
 
@@ -419,10 +423,12 @@ def test_fetch_tweets_full_text_is_list():
 
     assert len(result) == 1
     assert result[0]["text"] == "AGI is near"
+    assert result[0]["context_text"] == "quoted tweet text"
+    assert result[0]["is_repost"] is False
 
 
 def test_fetch_tweets_full_text_list_is_retweet():
-    """full_text 为列表且第一个元素是转推时，应被过滤。"""
+    """full_text 为列表且第一个元素是转推时，应提取原始内容并标记为转推。"""
     mock_client = MagicMock()
     mock_tweet = _make_tweet_item("111", ["RT @someone: original", "original"])
 
@@ -430,7 +436,9 @@ def test_fetch_tweets_full_text_list_is_retweet():
         mock_client.get_user_tweets.return_value = {"data": [MagicMock()]}
         result = fetch_tweets("sama", mock_client)
 
-    assert result == []
+    assert len(result) == 1
+    assert result[0]["is_repost"] is True
+    assert result[0]["context_author"] == "someone"
 
 
 def test_fetch_tweets_in_reply_to_is_list():


### PR DESCRIPTION
当 AI 领袖转发或引用别人的推文时，现在会显示被引用的原帖内容，
让读者能理解完整的来龙去脉，而不只是看到片段评论。

主要改动：
- fetch_tweets: 转推（RT @）不再过滤，改为提取原始内容+作者作为上下文
- fetch_tweets: 引用推文（full_text 为列表时的第二个元素）现在被捕获为 context_text
- TweetEntry: 新增 context_text / context_author / context_url / is_repost 字段
- _build_tweet_prompt_text: 将上下文信息纳入 LLM 翻译提示，生成更准确的摘要
- day.html.j2: 引用推文显示带"引用"标签的内嵌原帖块；转推显示"↩ 转发自 @handle"徽标
- 更新测试以反映新行为

https://claude.ai/code/session_01SCNPujEY4CYxTH1wZiMuT4