### PR TITLE
feat: 翻译转发/引用推文的原帖内容

### DIFF
--- a/src/pipeline.py
+++ b/src/pipeline.py
@@ -79,10 +79,12 @@ BATCH_PROMPT_TEMPLATE = """\
 [1]
 TITLE: 一句话核心观点（不超过 20 字）
 SUMMARY: 中文翻译（保留原意，如有引用请概括完整背景，不超过 150 字）
+CONTEXT: 被转发/引用原帖的直接中文翻译（仅当原文中含有转发或引用内容时填写，否则留空）
 
 [2]
 TITLE: ...
 SUMMARY: ...
+CONTEXT: ...
 
 推文原文：
 {tweets}"""
@@ -148,10 +150,11 @@ class TweetEntry:
     created_at: str
     title: str = ""
     summary: str = ""
-    context_text: str = ""    # 被引用/转发推文的内容
-    context_author: str = ""  # 被引用/转发推文的作者 handle
-    context_url: str = ""     # 被引用推文的链接
-    is_repost: bool = False   # True 表示纯转推（无评论）
+    context_text: str = ""        # 被引用/转发推文的内容（英文原文）
+    context_author: str = ""      # 被引用/转发推文的作者 handle
+    context_url: str = ""         # 被引用推文的链接
+    is_repost: bool = False       # True 表示纯转推（无评论）
+    context_translated: str = ""  # 被引用/转发推文的中文翻译
 
 
 # ---------------------------------------------------------------------------
@@ -345,6 +348,7 @@ def parse_llm_output(text: str, original: str) -> dict[str, str]:
     """
     title = ""
     summary = ""
+    context_translated = ""
 
     for line in text.strip().splitlines():
         stripped = line.strip()
@@ -352,14 +356,17 @@ def parse_llm_output(text: str, original: str) -> dict[str, str]:
             title = stripped[len("TITLE:"):].strip()
         elif stripped.startswith("SUMMARY:"):
             summary = stripped[len("SUMMARY:"):].strip()
+        elif stripped.startswith("CONTEXT:"):
+            context_translated = stripped[len("CONTEXT:"):].strip()
 
     if not title and not summary:
         logger.warning("LLM 输出格式不符，使用原文 fallback")
-        return {"title": "（原文）", "summary": original}
+        return {"title": "（原文）", "summary": original, "context_translated": ""}
 
     return {
         "title": title or "（无标题）",
         "summary": summary or original,
+        "context_translated": context_translated,
     }
 
 
@@ -595,6 +602,7 @@ def main() -> None:
                 context_author=tweet.get("context_author", ""),
                 context_url=tweet.get("context_url", ""),
                 is_repost=tweet.get("is_repost", False),
+                context_translated=translated.get("context_translated", ""),
             ))
             new_ids.add(tweet["id"])
 

--- a/templates/day.html.j2
+++ b/templates/day.html.j2
@@ -366,6 +366,11 @@
 
       {% if entry.is_repost and entry.context_author %}
       <div class="card-repost-badge">↩ 转发自 @{{ entry.context_author }}</div>
+      {% if entry.context_translated %}
+      <div class="card-context">
+        <div class="context-body">{{ entry.context_translated }}</div>
+      </div>
+      {% endif %}
       {% endif %}
 
       {% if entry.context_text and not entry.is_repost %}
@@ -380,7 +385,7 @@
           {% endif %}
           {% endif %}
         </div>
-        <div class="context-body">{{ entry.context_text }}</div>
+        <div class="context-body">{{ entry.context_translated if entry.context_translated else entry.context_text }}</div>
       </div>
       {% endif %}
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -205,6 +205,28 @@ def test_parse_llm_output_extra_prefix():
     assert result["summary"] == "核心摘要内容。"
 
 
+def test_parse_llm_output_with_context():
+    """含 CONTEXT: 字段时正确提取引用内容的中文翻译。"""
+    text = textwrap.dedent("""\
+        TITLE: 关于大胆程度的理论
+        SUMMARY: Swyx 转发了关于大胆程度的思考。
+        CONTEXT: 生活会在你大胆的程度上与你相遇。
+    """)
+    result = parse_llm_output(text, original="original")
+
+    assert result["title"] == "关于大胆程度的理论"
+    assert result["summary"] == "Swyx 转发了关于大胆程度的思考。"
+    assert result["context_translated"] == "生活会在你大胆的程度上与你相遇。"
+
+
+def test_parse_llm_output_empty_context():
+    """CONTEXT: 为空时 context_translated 为空字符串。"""
+    text = "TITLE: 标题\nSUMMARY: 摘要。\nCONTEXT:"
+    result = parse_llm_output(text, original="original")
+
+    assert result["context_translated"] == ""
+
+
 # ---------------------------------------------------------------------------
 # render_html
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
在批量翻译 prompt 中新增 CONTEXT: 字段，要求 LLM 同时翻译
被转发或引用的原帖内容，并将结果存入 TweetEntry.context_translated。

模板更新：
- 纯转发卡片（is_repost=True）：在 "↩ 转发自 @xxx" 徽标下方
  新增引用块，显示原帖的中文翻译
- 引用推文卡片（is_repost=False）：引用块优先展示中文翻译，
  无翻译时回退到英文原文

新增两个单元测试覆盖 CONTEXT: 字段的解析逻辑。

https://claude.ai/code/session_013Gg5hZ5tspwP9yqf1cdRsM