### PR TITLE
feat: add real Twitter profile avatars to person cards

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -46,6 +46,17 @@ jobs:
             fi
           done || true
 
+      - name: Restore cached avatars from gh-pages
+        run: |
+          mkdir -p docs/avatars
+          git ls-tree --name-only origin/gh-pages avatars/ 2>/dev/null | while read f; do
+            name=$(basename "$f")
+            git show origin/gh-pages:"$f" > "docs/avatars/$name" && echo "Restored avatar: $name"
+          done || true
+
+      - name: Download missing avatars
+        run: python scripts/fetch_avatars.py
+
       - name: Run pipeline
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
@@ -81,8 +92,10 @@ jobs:
           cp docs/index.html ./index.html
           mkdir -p archive
           [ -d docs/archive ] && cp -r docs/archive/. archive/ || true
+          mkdir -p avatars
+          [ -d docs/avatars ] && cp -r docs/avatars/. avatars/ || true
 
-          git add .nojekyll index.html archive/
+          git add .nojekyll index.html archive/ avatars/
           git diff --staged --quiet && echo "Nothing new to deploy" || \
             git commit -m "deploy: $(date +%Y-%m-%d)"
           git push origin gh-pages

--- a/scripts/fetch_avatars.py
+++ b/scripts/fetch_avatars.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Download Twitter profile avatars for all people in people.yml.
+
+Skips handles that already have a local file. Run this manually or from CI
+to populate docs/avatars/ before deploying to gh-pages.
+"""
+import time
+import urllib.request
+from pathlib import Path
+
+import yaml
+
+PEOPLE_FILE = Path(__file__).parent.parent / "people.yml"
+AVATARS_DIR = Path(__file__).parent.parent / "docs" / "avatars"
+HEADERS = {"User-Agent": "Mozilla/5.0 (compatible; AIDigestCN/1.0)"}
+
+
+def main() -> None:
+    with open(PEOPLE_FILE, encoding="utf-8") as f:
+        data = yaml.safe_load(f)
+
+    AVATARS_DIR.mkdir(parents=True, exist_ok=True)
+
+    for person in data.get("people", []):
+        handle = person["twitter_handle"]
+        out_path = AVATARS_DIR / f"{handle}.jpg"
+
+        if out_path.exists() and out_path.stat().st_size > 0:
+            print(f"  skip  @{handle} (already cached)")
+            continue
+
+        url = f"https://unavatar.io/twitter/{handle}"
+        print(f"  fetch @{handle} ... ", end="", flush=True)
+        try:
+            req = urllib.request.Request(url, headers=HEADERS)
+            with urllib.request.urlopen(req, timeout=20) as resp:
+                content = resp.read()
+            out_path.write_bytes(content)
+            print(f"OK ({len(content):,} bytes)")
+        except Exception as exc:
+            print(f"FAILED: {exc}")
+        time.sleep(0.4)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/pipeline.py
+++ b/src/pipeline.py
@@ -150,6 +150,7 @@ class TweetEntry:
     created_at: str
     title: str = ""
     summary: str = ""
+    twitter_handle: str = ""      # Twitter @handle（用于头像路径）
     context_text: str = ""        # 被引用/转发推文的内容（英文原文）
     context_author: str = ""      # 被引用/转发推文的作者 handle
     context_url: str = ""         # 被引用推文的链接
@@ -478,12 +479,13 @@ def render_html(
     entries: list[TweetEntry],
     today: str,
     archive_url: str = "archive/",
+    avatar_base: str = "avatars/",
     templates_dir: Path = TEMPLATES_DIR,
 ) -> str:
     """用 Jinja2 模板渲染 HTML。entries 为空时渲染空状态页面。"""
     env = Environment(loader=FileSystemLoader(str(templates_dir)), autoescape=True)
     template = env.get_template("day.html.j2")
-    return template.render(entries=entries, date=today, archive_url=archive_url)
+    return template.render(entries=entries, date=today, archive_url=archive_url, avatar_base=avatar_base)
 
 
 def render_archive_index(
@@ -593,6 +595,7 @@ def main() -> None:
                 tweet_id=tweet["id"],
                 person_id=person.id,
                 person_name=person.name,
+                twitter_handle=person.twitter_handle,
                 original_text=tweet["text"],
                 tweet_url=tweet["url"],
                 created_at=tweet["created_at"],
@@ -613,11 +616,11 @@ def main() -> None:
     # Main page: archive link is "archive/" (relative to root)
     # Archive date page: archive link is "./" (current directory = archive/)
     (DOCS_DIR / "index.html").write_text(
-        render_html(entries, today, archive_url="archive/"), encoding="utf-8"
+        render_html(entries, today, archive_url="archive/", avatar_base="avatars/"), encoding="utf-8"
     )
     if entries:
         (ARCHIVE_DIR / f"{today}.html").write_text(
-            render_html(entries, today, archive_url="./"), encoding="utf-8"
+            render_html(entries, today, archive_url="./", avatar_base="../avatars/"), encoding="utf-8"
         )
 
     archive_index = render_archive_index(ARCHIVE_DIR)

--- a/templates/day.html.j2
+++ b/templates/day.html.j2
@@ -153,6 +153,10 @@
       flex-shrink: 0;
       letter-spacing: -.01em;
     }
+    img.avatar {
+      background: var(--surface-2);
+      object-fit: cover;
+    }
     .identity-info { flex: 1; min-width: 0; }
     .author-name {
       font-family: 'Clash Grotesk', -apple-system, BlinkMacSystemFont, sans-serif;
@@ -351,7 +355,12 @@
     {% for entry in entries %}
     <article class="card">
       <div class="card-identity">
+        {% if entry.twitter_handle %}
+        <img class="avatar" src="{{ avatar_base }}{{ entry.twitter_handle }}.jpg" alt="{{ entry.person_name[0] }}" onerror="this.style.display='none';this.nextElementSibling.style.display='flex'">
+        <div class="avatar" style="display:none">{{ entry.person_name[0] }}</div>
+        {% else %}
         <div class="avatar">{{ entry.person_name[0] }}</div>
+        {% endif %}
         <div class="identity-info">
           <div class="author-name">{{ entry.person_name }}</div>
           <div class="author-meta">{{ entry.created_at }}</div>


### PR DESCRIPTION
- Add twitter_handle field to TweetEntry (optional, default "")
- Populate twitter_handle from Person when building entries
- Update template to show <img> avatar with letter fallback on error
- Pass avatar_base ("avatars/" / "../avatars/") so paths work for both
  root index.html and archive/YYYY-MM-DD.html
- Add scripts/fetch_avatars.py to download avatars via unavatar.io
- Update CI workflow to restore cached avatars from gh-pages, download
  missing ones, and deploy avatars/ alongside the HTML

https://claude.ai/code/session_01Xuk7Cge4w4JPoZeVQAj4F4